### PR TITLE
PR-08: Baselines (Free-form & Free-form+LLMLingua) + smoke + tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@
   - Evidence: pytest all green; smoke shows loose caps (density≈1.0, low overflow) vs tight caps (lower density, higher overflow).
   - Summary: Echo model yields deterministic outputs; manager message density drops as caps tighten; tokens_total and latency_ms reported.
 
+- PR‑08 — Baselines (Free‑form & Free‑form+LLMLingua):
+  - Adds `tersetalk/baselines.py` with `build_freeform_prompt`, `approx_token_count`, `run_freeform_once`, and `run_llmlingua_once` (import‑guarded, env `TERSETALK_DISABLE_LL2=1` to force fallback in CI).
+  - Adds `scripts/baselines_smoke.py` and `tests/test_baselines.py` (prompt content, schema checks, deterministic Echo, and LLMLingua disabled fallback).
+  - Evidence: pytest all green; offline smoke prints both baselines. With LL2 disabled: `used_llmlingua=false` and compression fields are null.
+  - Summary: Baselines return comparable token metrics and are offline‑safe; ready for head‑to‑head with pipeline in future PRs.
+
 - PR‑06 — Dataset Adapters (HotpotQA & GSM8K):
   - Adds `tersetalk/datasets.py` with `load_hotpotqa()` and `load_gsm8k()` returning normalized examples: {question, answer, facts, subgoal, assumptions}. Deterministic sampling by seed; offline‑first synthetic shards controlled by `TERSETALK_OFFLINE_DATA=1`.
   - Adds `scripts/datasets_smoke.py` and `tests/test_datasets.py` (determinism, schema, offline behavior; optional real smoke via `RUN_REAL_DATASETS=1`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,7 +204,7 @@ You must ensure that code you review follows the above principles
 - Check `@tests/test_datasets.py` covers determinism, schema, and offline behavior; optional real smoke gated by `RUN_REAL_DATASETS=1`.
 - Smoke: `@scripts/datasets_smoke.py` prints two samples per task with `offline` flag; include JSON in PR description.
 - If fully acceptable, end with exactly: `Approved: no nits.`
-- For PR-07 — Pipeline Runner (Manager→Worker→Critic)
+### For PR-07 — Pipeline Runner (Manager→Worker→Critic)
 
 - Validate `@tersetalk/pipeline_runner.py` provides:
   - `PipelineConfig`, `build_manager_message`, `prepare_critic_input`, `extract_answer`, `extract_verdict`, `run_pipeline_once`, `run_pipeline_batch`.
@@ -213,4 +213,14 @@ You must ensure that code you review follows the above principles
 - Check `@tests/test_pipeline_runner.py` covers schema and density behavior (loose vs tight caps) and determinism with Echo model + synthetic data.
 - Smoke: `@scripts/pipeline_smoke.py` prints one result JSON for Echo + synthetic tasks; include loose vs tight caps snippets in PR body.
 - Ensure reference to `@RESEARCH_PROPOSAL.md` (pipeline section) guides the review for alignment and scope.
+- If fully acceptable, end with exactly: `Approved: no nits.`
+
+### For PR-08 — Baselines (Free‑form & LLMLingua)
+
+- Validate `@tersetalk/baselines.py` provides:
+  - `build_freeform_prompt`, `approx_token_count`, `run_freeform_once`, `run_llmlingua_once`.
+  - LLMLingua path import‑guarded; honors `TERSETALK_DISABLE_LL2=1` to force fallback in CI.
+  - Returns dict with: answer, prompt, response, prompt_tokens, response_tokens, tokens_total, used_llmlingua, origin_tokens, compressed_tokens, compression_ratio.
+- Check `@tests/test_baselines.py` covers prompt content, schema, deterministic Echo, and LL2 disabled fallback.
+- Smoke: `@scripts/baselines_smoke.py` prints both baselines; include JSON snippets in PR body. Ensure review is aligned with @RESEARCH_PROPOSAL.md.
 - If fully acceptable, end with exactly: `Approved: no nits.`

--- a/scripts/baselines_smoke.py
+++ b/scripts/baselines_smoke.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from tersetalk.datasets import load_hotpotqa, load_gsm8k
+from tersetalk.model_io import EchoModel
+from tersetalk.baselines import run_freeform_once, run_llmlingua_once
+
+
+def main():
+  ap = argparse.ArgumentParser(description="PR-08: Baselines smoke (free-form & LLMLingua)")
+  ap.add_argument("--task", choices=["hotpotqa", "gsm8k"], default="hotpotqa")
+  ap.add_argument("--seed", type=int, default=0)
+  ap.add_argument("--offline", action="store_true")
+  ap.add_argument("--disable-ll2", action="store_true", help="Force disable LLMLingua via env")
+  args = ap.parse_args()
+
+  if args.disable_ll2:
+    os.environ["TERSETALK_DISABLE_LL2"] = "1"
+
+  offline = args.offline or (os.environ.get("TERSETALK_OFFLINE_DATA") == "1")
+
+  if args.task == "hotpotqa":
+    ex = load_hotpotqa(n=1, seed=args.seed, offline=offline)[0]
+  else:
+    ex = load_gsm8k(n=1, seed=args.seed, offline=offline)[0]
+
+  client = EchoModel()
+
+  print("=== Free-form baseline ===")
+  res_free = run_freeform_once(ex, client)
+  print(json.dumps(res_free, indent=2))
+
+  print("\n=== Free-form + LLMLingua baseline ===")
+  res_ll2 = run_llmlingua_once(ex, client, target_token=200)
+  print(json.dumps(res_ll2, indent=2))
+
+
+if __name__ == "__main__":
+  main()
+

--- a/tersetalk/__init__.py
+++ b/tersetalk/__init__.py
@@ -13,4 +13,5 @@ __all__ = [
   "model_io",
   "datasets",
   "pipeline_runner",
+  "baselines",
 ]

--- a/tersetalk/baselines.py
+++ b/tersetalk/baselines.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import os
+from typing import Dict, Optional
+
+from tersetalk.model_io import ModelClient
+
+
+# ---- Utilities ----
+
+
+def approx_token_count(text: str) -> int:
+  """4 chars ≈ 1 token fallback. Non-negative."""
+  if not isinstance(text, str):
+    return 0
+  return max(0, (len(text) + 3) // 4)
+
+
+def build_freeform_prompt(example: Dict) -> str:
+  """
+  Construct a concise, readable free-form prompt from a normalized example:
+  {question, answer, facts, subgoal, assumptions}
+  """
+  question = str(example.get("question", "")).strip()
+  subgoal = str(example.get("subgoal", "")).strip()
+  facts = [str(f) for f in (example.get("facts", []) or [])][:10]
+  assumptions = [str(a) for a in (example.get("assumptions", []) or [])][:5]
+
+  facts_block = ""
+  if facts:
+    facts_block = "Facts:\n" + "\n".join(f"- {f}" for f in facts)
+
+  assumptions_block = ""
+  if assumptions:
+    assumptions_block = "Assumptions:\n" + "\n".join(f"- {a}" for a in assumptions)
+
+  # Keep compact and deterministic; baseline expects plain text.
+  prompt = f"""Role: Manager
+
+Goal: {subgoal or "Answer the user's question correctly and concisely."}
+{facts_block}
+
+{assumptions_block}
+
+Question:
+{question}
+
+Instructions:
+Provide only the final answer as one or two short sentences.
+"""
+  # Remove empty lines except allow lone 'Question:' if needed
+  return "\n".join(ln for ln in prompt.splitlines() if ln.strip() or ln == "Question:")
+
+
+# ---- Baseline runners ----
+
+
+def run_freeform_once(example: Dict, client: ModelClient) -> Dict:
+  """
+  Free-form (no compression) baseline.
+  Uses ModelClient.call_text to obtain a plain-text response.
+  """
+  prompt = build_freeform_prompt(example)
+  system = "You are a helpful, concise assistant."
+  response = client.call_text(system=system, user_prompt=prompt, max_tokens=256)
+
+  prompt_tokens = approx_token_count(prompt)
+  response_tokens = approx_token_count(response)
+  return {
+    "answer": response.strip(),
+    "prompt": prompt,
+    "response": response,
+    "prompt_tokens": int(prompt_tokens),
+    "response_tokens": int(response_tokens),
+    "tokens_total": int(prompt_tokens + response_tokens),
+    "used_llmlingua": False,
+    "origin_tokens": None,
+    "compressed_tokens": None,
+    "compression_ratio": None,
+  }
+
+
+def run_llmlingua_once(example: Dict, client: ModelClient, target_token: int = 400) -> Dict:
+  """
+  Free-form + LLMLingua baseline.
+  - If LLMLingua is unavailable or disabled (TERSETALK_DISABLE_LL2=1), falls back to
+    uncompressed prompt but still returns the schema with used_llmlingua=False and
+    None for compression fields.
+  """
+  prompt = build_freeform_prompt(example)
+  system = "You are a helpful, concise assistant."
+
+  # Honor env switch to make CI deterministic
+  if os.environ.get("TERSETALK_DISABLE_LL2", "0") == "1":
+    response = client.call_text(system=system, user_prompt=prompt, max_tokens=256)
+    pt = approx_token_count(prompt)
+    rt = approx_token_count(response)
+    return {
+      "answer": response.strip(),
+      "prompt": prompt,
+      "response": response,
+      "prompt_tokens": int(pt),
+      "response_tokens": int(rt),
+      "tokens_total": int(pt + rt),
+      "used_llmlingua": False,
+      "origin_tokens": None,
+      "compressed_tokens": None,
+      "compression_ratio": None,
+    }
+
+  try:
+    from llmlingua import PromptCompressor  # type: ignore
+
+    compressor = PromptCompressor()
+    comp = compressor.compress(prompt, target_token=int(target_token))
+
+    compressed_prompt = comp.get("compressed_prompt") or comp.get("compressed_text") or prompt
+    origin_tokens = int(comp.get("origin_tokens") or approx_token_count(prompt))
+    compressed_tokens = int(comp.get("compressed_tokens") or approx_token_count(compressed_prompt))
+    ratio = float(comp.get("ratio") or (compressed_tokens / max(1, origin_tokens)))
+
+    response = client.call_text(system=system, user_prompt=compressed_prompt, max_tokens=256)
+
+    resp_tokens = approx_token_count(response)
+    return {
+      "answer": response.strip(),
+      "prompt": compressed_prompt,
+      "response": response,
+      "prompt_tokens": int(compressed_tokens),
+      "response_tokens": int(resp_tokens),
+      "tokens_total": int(compressed_tokens + resp_tokens),
+      "used_llmlingua": True,
+      "origin_tokens": origin_tokens,
+      "compressed_tokens": compressed_tokens,
+      "compression_ratio": ratio,
+    }
+  except Exception:
+    # Graceful fallback if library missing or runtime error
+    response = client.call_text(system=system, user_prompt=prompt, max_tokens=256)
+    pt = approx_token_count(prompt)
+    rt = approx_token_count(response)
+    return {
+      "answer": response.strip(),
+      "prompt": prompt,
+      "response": response,
+      "prompt_tokens": int(pt),
+      "response_tokens": int(rt),
+      "tokens_total": int(pt + rt),
+      "used_llmlingua": False,
+      "origin_tokens": None,
+      "compressed_tokens": None,
+      "compression_ratio": None,
+    }
+

--- a/tests/test_baselines.py
+++ b/tests/test_baselines.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+
+from tersetalk.baselines import build_freeform_prompt, run_freeform_once, run_llmlingua_once
+from tersetalk.datasets import load_hotpotqa
+from tersetalk.model_io import EchoModel
+
+
+def _shape_ok(res: dict, expect_ll2: bool | None = None):
+  keys = {
+    "answer",
+    "prompt",
+    "response",
+    "prompt_tokens",
+    "response_tokens",
+    "tokens_total",
+    "used_llmlingua",
+    "origin_tokens",
+    "compressed_tokens",
+    "compression_ratio",
+  }
+  assert keys.issubset(set(res.keys()))
+  assert isinstance(res["answer"], str)
+  assert isinstance(res["prompt_tokens"], int)
+  assert isinstance(res["response_tokens"], int)
+  assert isinstance(res["tokens_total"], int)
+  if expect_ll2 is not None:
+    assert res["used_llmlingua"] is expect_ll2
+  if not expect_ll2:
+    assert res["origin_tokens"] is None
+    assert res["compressed_tokens"] is None
+    assert res["compression_ratio"] is None
+
+
+def test_build_freeform_prompt_contains_question_and_fact(monkeypatch):
+  monkeypatch.setenv("TERSETALK_OFFLINE_DATA", "1")
+  ex = load_hotpotqa(n=1, seed=3)[0]
+  prompt = build_freeform_prompt(ex)
+  assert "Question:" in prompt
+  assert ex["question"][:10] in prompt
+  if ex.get("facts"):
+    assert str(ex["facts"][0])[:5] in prompt
+
+
+def test_run_freeform_once_echo_is_deterministic(monkeypatch):
+  monkeypatch.setenv("TERSETALK_OFFLINE_DATA", "1")
+  ex = load_hotpotqa(n=1, seed=5)[0]
+  client = EchoModel()
+  r1 = run_freeform_once(ex, client)
+  r2 = run_freeform_once(ex, client)
+  _shape_ok(r1)
+  assert r1["answer"] == r2["answer"]
+  assert r1["tokens_total"] == r2["tokens_total"]
+
+
+def test_run_llmlingua_once_fallback_when_disabled(monkeypatch):
+  # Force disable LLMLingua through env to ensure deterministic CI
+  monkeypatch.setenv("TERSETALK_OFFLINE_DATA", "1")
+  monkeypatch.setenv("TERSETALK_DISABLE_LL2", "1")
+
+  ex = load_hotpotqa(n=1, seed=7)[0]
+  client = EchoModel()
+  r = run_llmlingua_once(ex, client, target_token=200)
+  _shape_ok(r, expect_ll2=False)
+

--- a/todos.txt
+++ b/todos.txt
@@ -1,0 +1,30 @@
+TerseTalk – Follow‑up TODOs (not explicitly covered in RESEARCH_PROPOSAL.md)
+
+Context: These are small, high‑leverage improvements that harden UX and testing
+around the current pipeline/baselines without changing research scope.
+
+1) PR‑08S — Smoke CLIs: model selector
+   - Add --model=echo|real to scripts/pipeline_smoke.py and scripts/baselines_smoke.py.
+   - Default to echo (offline‑safe); real path uses ModelClient.
+   - Tests: CLI parses flags; real path skipped unless RUN_REAL_MODEL=1.
+
+2) PR‑09R — Pipeline robustness to model schema failures
+   - Wrap Worker/Critic structured calls in try/except inside run_pipeline_once.
+   - Record failure fields (e.g., {"worker_error": str, "critic_error": str, "status": "error"}).
+   - Ensure memory reset still occurs; density/overflow still computed from manager message.
+   - Tests: simulate Instructor exceptions; verify non‑crash + fields present.
+
+3) PR‑09T — Optional tokenizer (tiktoken) for token counts
+   - Import‑guarded tiktoken support; fallback to len/4 heuristic.
+   - Tests: when absent → heuristic path; when present → counts are non‑negative and consistent.
+
+4) PR‑08B — Baselines knobs & minor nits
+   - Parameterize max_tokens in run_freeform_once/run_llmlingua_once; surface via smoke CLI.
+   - Add brief comment in build_freeform_prompt explaining lone "Question:" line retention.
+   - Tests: determinism unchanged with default params; schema intact.
+
+5) PR‑UX — Unified real‑run toggles & env docs
+   - Consolidate RUN_REAL_MODEL, TERSETALK_OFFLINE_DATA, RUN_REAL_DATASETS, TERSETALK_DISABLE_LL2 docs.
+   - Quick section in README/AGENTS for real‑run setup (Ollama/OpenAI), without making network required.
+
+Note: The evaluation harness and accuracy metrics are planned in RESEARCH_PROPOSAL.md; not tracked here.


### PR DESCRIPTION
PR‑08 — Baselines: free‑form & LLMLingua

Summary
- Add `tersetalk/baselines.py` with:
  - `build_freeform_prompt`, `approx_token_count`, `run_freeform_once`, `run_llmlingua_once`
  - LLMLingua path import‑guarded; `TERSETALK_DISABLE_LL2=1` forces fallback (CI-safe)
- Add `scripts/baselines_smoke.py` for quick offline smokes
- Add `tests/test_baselines.py` validating prompt content, schema, deterministic Echo, and LL2‑disabled fallback
- Export `baselines` in `tersetalk/__init__.py`
- Update `AGENTS.md` and `CLAUDE.md` with PR‑08 entry and review guidance

DoD
- Baselines return comparable fields: `answer`, `prompt`, `response`, `prompt_tokens`, `response_tokens`, `tokens_total`, and LL2 compression fields (present or None)
- No network required for tests; EchoModel used for determinism

Evidence (ran in .venv)
1) Pytest: all green

2) Offline smoke (HotpotQA; LL2 disabled for determinism)
```
TERSETALK_OFFLINE_DATA=1 TERSETALK_DISABLE_LL2=1 python -m scripts.baselines_smoke --task hotpotqa --seed 42 --offline --disable-ll2
```
Output excerpt:
```
=== Free-form baseline ===
{
  "prompt_tokens": 86,
  "response_tokens": 7,
  "tokens_total": 93,
  "used_llmlingua": false
}

=== Free-form + LLMLingua baseline ===
{
  "prompt_tokens": 86,
  "response_tokens": 7,
  "tokens_total": 93,
  "used_llmlingua": false
}
```

Process & Reviews
- Self-review: ✅ minimal diffs; tests pass; docs updated; env‑guarded behavior for CI
- Claude review: Pending — refs‑only review (reads @RESEARCH_PROPOSAL.md first) starting now
- Final self-review: Will re‑run after Claude feedback and before merge

Notes & rationale
- Plain‑text API: Baselines rely on `ModelClient.call_text`; structured paths untouched
- Token heuristic: 4 chars ≈ 1 token, matching prior modules until optional tokenizer is enabled later
- LLMLingua: Gracefully degrades when missing; explicit env switch ensures determinism in CI

