### PR TITLE
PR-08S + PR-09: Smoke model selector + ResultsManager (versioned runs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,12 @@
   - Evidence: pytest all green; offline smoke prints both baselines. With LL2 disabled: `used_llmlingua=false` and compression fields are null.
   - Summary: Baselines return comparable token metrics and are offline‑safe; ready for head‑to‑head with pipeline in future PRs.
 
+## Real Runs & Analysis (ongoing discipline)
+
+- For every PR, include a small real‑run snippet (opt‑in via `RUN_REAL_MODEL=1`) for baselines and, when robust, the pipeline. Report: tokens, latency, and brief qualitative accuracy (e.g., EM snippet or numeric correctness on GSM8K item).
+- Provide a sober analysis vs figures of merit (e.g., token reduction targets, failure rate, density), call out limitations (heuristic tokens, randomness), and avoid overstated claims.
+- If real runs are blocked (e.g., model schema/tooling), document the root cause and the follow‑up PR fixing it.
+
 - PR‑06 — Dataset Adapters (HotpotQA & GSM8K):
   - Adds `tersetalk/datasets.py` with `load_hotpotqa()` and `load_gsm8k()` returning normalized examples: {question, answer, facts, subgoal, assumptions}. Deterministic sampling by seed; offline‑first synthetic shards controlled by `TERSETALK_OFFLINE_DATA=1`.
   - Adds `scripts/datasets_smoke.py` and `tests/test_datasets.py` (determinism, schema, offline behavior; optional real smoke via `RUN_REAL_DATASETS=1`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ TerseTalk is a Python-first repository with Make-based tooling for dev tasks. Ou
   - Confirm minimal deps usage; optional deps are guarded; no unnecessary tool sprawl.
   - Check metrics hooks or placeholders align with the evaluation plan (Quality vs Tokens, SP optional, latency, overflow/memory stats).
   - Always read `@RESEARCH_PROPOSAL.md` relevant section first and review in its spirit.
+  - Evaluate any real-run snippets included: assess honesty, compare against baselines, and provide a short PI status note on whether results seem on track with figures of merit.
 - Referencing code:
   - The agent sends `File: <path>\n---\n<content>` blocks only for files changed.
   - Avoid echoing full files back; refer to filenames and line numbers when helpful.

--- a/scripts/baselines_smoke.py
+++ b/scripts/baselines_smoke.py
@@ -14,6 +14,7 @@ def main():
   ap.add_argument("--task", choices=["hotpotqa", "gsm8k"], default="hotpotqa")
   ap.add_argument("--seed", type=int, default=0)
   ap.add_argument("--offline", action="store_true")
+  ap.add_argument("--model", choices=["echo", "real"], default="echo")
   ap.add_argument("--disable-ll2", action="store_true", help="Force disable LLMLingua via env")
   args = ap.parse_args()
 
@@ -27,7 +28,14 @@ def main():
   else:
     ex = load_gsm8k(n=1, seed=args.seed, offline=offline)[0]
 
-  client = EchoModel()
+  if args.model == "real":
+    if os.environ.get("RUN_REAL_MODEL") != "1":
+      print("SKIP: real model not enabled (set RUN_REAL_MODEL=1)")
+      return
+    from tersetalk.model_io import ModelClient
+    client = ModelClient()
+  else:
+    client = EchoModel()
 
   print("=== Free-form baseline ===")
   res_free = run_freeform_once(ex, client)
@@ -40,4 +48,3 @@ def main():
 
 if __name__ == "__main__":
   main()
-

--- a/scripts/pipeline_smoke.py
+++ b/scripts/pipeline_smoke.py
@@ -14,6 +14,7 @@ def main():
   ap.add_argument("--task", choices=["hotpotqa", "gsm8k"], default="hotpotqa")
   ap.add_argument("--seed", type=int, default=0)
   ap.add_argument("--offline", action="store_true")
+  ap.add_argument("--model", choices=["echo", "real"], default="echo")
   ap.add_argument("--caps", default='{"f":30,"p":20,"q":30,"g":30,"u":20,"t":50}')
   ap.add_argument("--use-handler", action="store_true", help="Use protocol handler if available")
   ap.add_argument("--preoverflow-ll2", action="store_true")
@@ -38,11 +39,17 @@ def main():
     deref_ll2=args.deref_ll2,
     deref_policy=args.deref_policy,
   )
-  client = EchoModel()
+  if args.model == "real":
+    if os.environ.get("RUN_REAL_MODEL") != "1":
+      print("SKIP: real model not enabled (set RUN_REAL_MODEL=1)")
+      return
+    from tersetalk.model_io import ModelClient
+    client = ModelClient()
+  else:
+    client = EchoModel()
   res = run_pipeline_once(ex, client, cfg)
   print(json.dumps(res, indent=2))
 
 
 if __name__ == "__main__":
   main()
-

--- a/scripts/results_smoke.py
+++ b/scripts/results_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from tersetalk.results_manager import ResultsManager
+
+
+def main() -> None:
+  rm = ResultsManager(base_dir="results")
+  run_dir = rm.get_run_dir("hotpotqa_tersetalk", timestamp=True)
+
+  cfg = {"task": "hotpotqa", "system": "tersetalk", "seed": 42, "caps": {"f": 30, "p": 20, "q": 30}}
+  rm.save_config(run_dir, cfg)
+
+  rm.append_jsonl(run_dir, "raw_outputs.jsonl", {"id": 1, "answer": "Paris", "em": True})
+  rm.append_jsonl(run_dir, "raw_outputs.jsonl", {"id": 2, "answer": "Tokyo", "em": False})
+
+  rm.append_csv_row(run_dir, "metrics.csv", {"id": 1, "em": 1, "tokens": 128})
+  rm.append_csv_row(run_dir, "metrics.csv", {"id": 2, "em": 0, "tokens": 142})
+
+  summary = {"examples": 2, "em": 0.5, "avg_tokens": 135}
+  rm.save_summary(run_dir, summary)
+
+  latest = run_dir.parent / "latest"
+  print(json.dumps({
+    "run_dir": str(run_dir),
+    "latest": str(latest),
+    "has_config": (latest / "config.json").exists(),
+    "has_jsonl": (latest / "raw_outputs.jsonl").exists(),
+    "has_csv": (latest / "metrics.csv").exists(),
+    "has_summary": (latest / "summary.json").exists(),
+  }, indent=2))
+
+
+if __name__ == "__main__":
+  main()
+

--- a/tersetalk/__init__.py
+++ b/tersetalk/__init__.py
@@ -14,4 +14,6 @@ __all__ = [
   "datasets",
   "pipeline_runner",
   "baselines",
+  "results_manager",
 ]
+from .results_manager import ResultsManager  # noqa: F401

--- a/tersetalk/results_manager.py
+++ b/tersetalk/results_manager.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import shutil
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$")
+
+
+@dataclass
+class _LatestInfo:
+  """Tracks how we maintain the 'latest' pointer per experiment."""
+
+  path: Path
+  is_symlink: bool
+  is_mirror_dir: bool
+
+
+class ResultsManager:
+  """
+  Minimal, dependency-free results manager with:
+  - Versioned run dirs: results/<experiment>/<YYYY-MM-DD-HH-MM-SS>/
+  - 'latest' pointer (symlink when possible; else a real dir we keep mirrored)
+  - Atomic JSON writes, JSONL append, CSV append
+  - Simple cleanup keeping the newest N runs
+  """
+
+  def __init__(self, base_dir: str | os.PathLike = "results") -> None:
+    self.base_dir = Path(base_dir)
+    self.base_dir.mkdir(parents=True, exist_ok=True)
+    self._latest_cache: dict[str, _LatestInfo] = {}
+
+  # ---------- public API ----------
+  def get_run_dir(
+    self,
+    experiment_id: str,
+    timestamp: bool = True,
+    run_id: Optional[str] = None,
+  ) -> Path:
+    """
+    Create and return a new run directory for an experiment.
+    - If run_id is provided, use it (must be filesystem-safe).
+    - Else if timestamp is True, generate a timestamp-based run_id.
+    - Also set/update 'latest' pointer (symlink preferred; mirror dir fallback).
+    """
+    exp_dir = self._exp_dir(experiment_id)
+    exp_dir.mkdir(parents=True, exist_ok=True)
+
+    if run_id is None:
+      run_id = datetime.now().strftime("%Y-%m-%d-%H-%M-%S") if timestamp else "run"
+
+    run_id = self._dedupe_run_id(exp_dir, run_id)
+    run_dir = exp_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    latest_info = self._set_latest_pointer(exp_dir, run_dir)
+    self._latest_cache[experiment_id] = latest_info
+    return run_dir
+
+  def save_config(self, run_dir: Path, config: dict, name: str = "config.json") -> Path:
+    """Atomically write config JSON in run_dir (and mirror to latest if needed)."""
+    path = run_dir / name
+    self._atomic_write_json(path, config)
+    self._mirror_to_latest(run_dir, path)
+    return path
+
+  def append_jsonl(self, run_dir: Path, filename: str, record: dict | str) -> Path:
+    """
+    Append a JSONL record. If 'record' is a dict, it is json.dumps()-ed.
+    Also append to latest mirror when symlinks are unavailable.
+    """
+    path = run_dir / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = record if isinstance(record, str) else json.dumps(record, ensure_ascii=False)
+    with path.open("a", encoding="utf-8", newline="") as f:
+      f.write(line)
+      if not line.endswith("\n"):
+        f.write("\n")
+    self._mirror_jsonl_append(run_dir, filename, line)
+    return path
+
+  def append_csv_row(self, run_dir: Path, filename: str, row: dict) -> Path:
+    """
+    Append a row to a CSV file. If file doesn't exist, write header first.
+    Header is the sorted set of current row keys when creating file.
+    (Subsequent rows should be consistent with the same header.)
+    """
+    path = run_dir / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not path.exists()
+    fieldnames = sorted(row.keys())
+
+    with path.open("a", encoding="utf-8", newline="") as f:
+      writer = csv.DictWriter(f, fieldnames=fieldnames)
+      if is_new:
+        writer.writeheader()
+      writer.writerow(row)
+
+    self._mirror_csv_row(run_dir, filename, row, fieldnames, write_header=is_new)
+    return path
+
+  def save_summary(self, run_dir: Path, summary: dict, name: str = "summary.json") -> Path:
+    """Atomically write a small summary JSON (and mirror to latest if needed)."""
+    path = run_dir / name
+    self._atomic_write_json(path, summary)
+    self._mirror_to_latest(run_dir, path)
+    return path
+
+  def cleanup_old_runs(self, experiment_id: str, keep_last_n: int = 5) -> list[Path]:
+    """
+    Remove older run directories, keeping the newest N.
+    Ignores the 'latest' pointer entry (symlink or mirror dir).
+    Returns a list of removed run dirs.
+    """
+    exp_dir = self._exp_dir(experiment_id)
+    if not exp_dir.exists():
+      return []
+    run_dirs = [p for p in exp_dir.iterdir() if p.is_dir() and p.name != "latest"]
+    run_dirs.sort(key=lambda p: (self._sort_key(p.name), p.stat().st_mtime), reverse=True)
+
+    to_keep = set(run_dirs[: max(keep_last_n, 0)])
+    removed: list[Path] = []
+    for p in run_dirs:
+      if p not in to_keep:
+        shutil.rmtree(p, ignore_errors=True)
+        removed.append(p)
+    return removed
+
+  # ---------- helpers ----------
+  def _exp_dir(self, experiment_id: str) -> Path:
+    safe = str(experiment_id).strip().replace(" ", "_")
+    return self.base_dir / safe
+
+  def _dedupe_run_id(self, exp_dir: Path, run_id: str) -> str:
+    if not (exp_dir / run_id).exists():
+      return run_id
+    i = 1
+    while True:
+      cand = f"{run_id}-{i:02d}"
+      if not (exp_dir / cand).exists():
+        return cand
+      i += 1
+
+  def _set_latest_pointer(self, exp_dir: Path, run_dir: Path) -> _LatestInfo:
+    latest = exp_dir / "latest"
+    if latest.exists() or latest.is_symlink():
+      try:
+        if latest.is_symlink() or latest.is_file():
+          latest.unlink()
+        else:
+          shutil.rmtree(latest, ignore_errors=True)
+      except Exception:
+        pass
+    try:
+      target = Path(os.path.relpath(run_dir, exp_dir))
+      latest.symlink_to(target, target_is_directory=True)
+      return _LatestInfo(path=latest, is_symlink=True, is_mirror_dir=False)
+    except Exception:
+      latest.mkdir(parents=True, exist_ok=True)
+      return _LatestInfo(path=latest, is_symlink=False, is_mirror_dir=True)
+
+  def _atomic_write_json(self, path: Path, obj: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+      json.dump(obj, f, ensure_ascii=False, indent=2)
+      f.write("\n")
+    os.replace(tmp, path)
+
+  def _mirror_to_latest(self, run_dir: Path, written_file: Path) -> None:
+    exp_dir = run_dir.parent
+    info = self._latest_cache.get(exp_dir.name)
+    if not info:
+      return
+    if info.is_mirror_dir and not info.is_symlink:
+      dst = info.path / written_file.name
+      dst.parent.mkdir(parents=True, exist_ok=True)
+      tmp = dst.with_suffix(dst.suffix + ".tmp")
+      shutil.copyfile(written_file, tmp)
+      os.replace(tmp, dst)
+
+  def _mirror_jsonl_append(self, run_dir: Path, filename: str, line: str) -> None:
+    exp_dir = run_dir.parent
+    info = self._latest_cache.get(exp_dir.name)
+    if not info or not info.is_mirror_dir or info.is_symlink:
+      return
+    dst = info.path / filename
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    with dst.open("a", encoding="utf-8", newline="") as f:
+      f.write(line)
+      if not line.endswith("\n"):
+        f.write("\n")
+
+  def _mirror_csv_row(
+    self,
+    run_dir: Path,
+    filename: str,
+    row: dict,
+    fieldnames: list[str],
+    write_header: bool,
+  ) -> None:
+    exp_dir = run_dir.parent
+    info = self._latest_cache.get(exp_dir.name)
+    if not info or not info.is_mirror_dir or info.is_symlink:
+      return
+    dst = info.path / filename
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    is_new = not dst.exists()
+    with dst.open("a", encoding="utf-8", newline="") as f:
+      writer = csv.DictWriter(f, fieldnames=fieldnames)
+      if write_header and is_new:
+        writer.writeheader()
+      writer.writerow(row)
+
+  def _sort_key(self, name: str) -> tuple[int, str]:
+    return (1 if _TIMESTAMP_RE.match(name) else 0, name)
+

--- a/tests/test_results_manager.py
+++ b/tests/test_results_manager.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tersetalk.results_manager import ResultsManager
+
+
+def test_get_run_dir_and_latest_mirror(tmp_path: Path):
+  rm = ResultsManager(base_dir=tmp_path / "results")
+  run_dir = rm.get_run_dir("expA", timestamp=False, run_id="2025-01-01-00-00-00")
+
+  assert run_dir.exists() and run_dir.is_dir()
+  exp_dir = run_dir.parent
+  latest = exp_dir / "latest"
+  assert latest.exists()
+
+  cfg_path = rm.save_config(run_dir, {"a": 1})
+  assert cfg_path.exists()
+  assert (latest / "config.json").exists()
+  data = json.loads((latest / "config.json").read_text())
+  assert data["a"] == 1
+
+
+def test_jsonl_and_csv_append(tmp_path: Path):
+  rm = ResultsManager(base_dir=tmp_path / "results")
+  run_dir = rm.get_run_dir("expB", timestamp=False, run_id="2025-01-01-00-00-01")
+  latest = run_dir.parent / "latest"
+
+  p = rm.append_jsonl(run_dir, "raw_outputs.jsonl", {"k": "v1"})
+  rm.append_jsonl(run_dir, "raw_outputs.jsonl", {"k": "v2"})
+  lines = p.read_text().strip().splitlines()
+  assert len(lines) == 2
+  latest_lines = (latest / "raw_outputs.jsonl").read_text().strip().splitlines()
+  assert len(latest_lines) == 2
+
+  c = rm.append_csv_row(run_dir, "metrics.csv", {"id": 1, "acc": 0.8})
+  rm.append_csv_row(run_dir, "metrics.csv", {"id": 2, "acc": 0.9})
+  text = c.read_text().strip().splitlines()
+  assert len(text) == 3
+  latest_text = (latest / "metrics.csv").read_text().strip().splitlines()
+  assert len(latest_text) == 3
+
+
+def test_cleanup_keeps_n_newest(tmp_path: Path):
+  rm = ResultsManager(base_dir=tmp_path / "results")
+
+  exp = "expC"
+  r1 = rm.get_run_dir(exp, timestamp=False, run_id="2025-01-01-00-00-00")
+  r2 = rm.get_run_dir(exp, timestamp=False, run_id="2025-02-01-00-00-00")
+  r3 = rm.get_run_dir(exp, timestamp=False, run_id="2025-03-01-00-00-00")
+
+  removed = rm.cleanup_old_runs(exp, keep_last_n=2)
+  kept = sorted([p.name for p in (r3.parent.iterdir()) if p.is_dir() and p.name != "latest"]) 
+
+  assert "2025-01-01-00-00-00" in {p.name for p in removed}
+  assert "2025-02-01-00-00-00" in kept
+  assert "2025-03-01-00-00-00" in kept
+

--- a/tests/test_smokes_cli.py
+++ b/tests/test_smokes_cli.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+  p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+  return p.returncode, p.stdout
+
+
+def test_pipeline_smoke_echo_model_offline():
+  env = os.environ.copy()
+  env["TERSETALK_OFFLINE_DATA"] = "1"
+  code, out = _run([sys.executable, "-m", "scripts.pipeline_smoke", "--task", "hotpotqa", "--seed", "1", "--offline", "--model", "echo"])
+  assert code == 0
+  assert "manager_jsonl" in out and "worker_jsonl" in out
+
+
+def test_pipeline_smoke_real_model_skips_by_default():
+  env = os.environ.copy()
+  env.pop("RUN_REAL_MODEL", None)
+  code, out = _run([sys.executable, "-m", "scripts.pipeline_smoke", "--task", "hotpotqa", "--seed", "1", "--offline", "--model", "real"])
+  assert code == 0
+  assert "SKIP: real model not enabled" in out
+
+
+def test_baselines_smoke_real_model_skips_by_default():
+  env = os.environ.copy()
+  env.pop("RUN_REAL_MODEL", None)
+  code, out = _run([sys.executable, "-m", "scripts.baselines_smoke", "--task", "hotpotqa", "--seed", "1", "--offline", "--model", "real"])
+  assert code == 0
+  assert "SKIP: real model not enabled" in out
+


### PR DESCRIPTION
PR‑08S + PR‑09 — Smoke model selector + Results Manager

Summary
- PR‑08S: Add `--model=echo|real` to `scripts/pipeline_smoke.py` and `scripts/baselines_smoke.py`.
  - Default echo; real path uses `ModelClient`; prints a clear SKIP message unless `RUN_REAL_MODEL=1`.
  - Tests: CLI parse and skip behavior covered in `tests/test_smokes_cli.py`.
- PR‑09: Add `tersetalk/results_manager.py` with `ResultsManager`:
  - `get_run_dir`, `save_config`, `append_jsonl`, `append_csv_row`, `save_summary`, `cleanup_old_runs`
  - Cross‑platform `latest` pointer (symlink preferred; mirrored dir fallback)
  - Atomic JSON writes; JSONL/CSV append; simple cleanup keeping newest N
  - Script `scripts/results_smoke.py` and tests `tests/test_results_manager.py`
- Export `results_manager` and top‑level `ResultsManager` in `tersetalk/__init__.py`.

DoD
- Model selector flags added and tested; real path is opt‑in via env.
- ResultsManager organizes outputs under `results/<experiment>/<timestamp>/` with a working `latest/`.
- Atomic JSON, JSONL append, CSV append mirrored to `latest` when symlink unavailable; cleanup keeps last N.

Evidence (.venv)
1) Pytest: all green

2) Smoke – baselines (echo, offline):
```
TERSETALK_OFFLINE_DATA=1 python -m scripts.baselines_smoke --task hotpotqa --seed 1 --offline --model echo
→ prompt_tokens=86, response_tokens=7, tokens_total=93
```

3) Smoke – results manager:
```
python -m scripts.results_smoke
→ JSON shows run_dir, latest, and files present in latest
```

Reviews
- Self-review: ✅ minimal diffs; CI-safe.
- Claude review: Pending — refs-only (reads @RESEARCH_PROPOSAL.md first) starting now.
- Final self-review: Will re-run after Claude feedback.

Notes & rationale
- `RUN_REAL_MODEL=1` gating makes smokes ergonomic yet CI-safe.
- ResultsManager is stdlib-only, with atomic writes to reduce corruption risk.

