### PR TITLE
PR-09R/09T/10: Pipeline robustness + optional tokenizer + metrics module

### DIFF
--- a/scripts/metrics_smoke.py
+++ b/scripts/metrics_smoke.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from tersetalk.metrics import MetricsComputer
+
+
+def main() -> None:
+  mc = MetricsComputer(use_tiktoken=False)
+
+  pred = "The Eiffel Tower!"
+  gold = "eiffel tower"
+  em = mc.exact_match(pred, gold)
+
+  p = "Therefore, the answer is \\boxed{1 3/4}."
+  g = "7/4"
+  gsm_ok = mc.gsm8k_correct(p, g)
+
+  sp = mc.bertscore_sp("a quick brown fox", "a fast brown fox", force_fallback=True)
+
+  toks = mc.count_tokens('["f","Paris"]\n["q","W","Capital?"]')
+  timing = mc.measure_generation_timing(start=0.00, ttft=0.02, end=0.12, tokens=8)
+
+  bow = mc.bytes_on_wire('["f","Paris"]\n')
+
+  out = {
+    "em_demo": em,
+    "gsm8k_demo": gsm_ok,
+    "sp_demo": sp,
+    "token_count_demo": toks,
+    "timing_demo": timing,
+    "bytes_on_wire_demo": bow,
+  }
+  print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+  main()
+

--- a/tersetalk/__init__.py
+++ b/tersetalk/__init__.py
@@ -15,5 +15,7 @@ __all__ = [
   "pipeline_runner",
   "baselines",
   "results_manager",
+  "metrics",
 ]
+from .metrics import MetricsComputer  # noqa: F401
 from .results_manager import ResultsManager  # noqa: F401

--- a/tersetalk/metrics.py
+++ b/tersetalk/metrics.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import math
+import re
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from fractions import Fraction
+from typing import Iterable, Optional, Union
+
+_TIKTOKEN = None
+_BERT_SCORE = None
+
+
+def _lazy_import_tiktoken(encoder_name: str = "cl100k_base"):
+  global _TIKTOKEN
+  if _TIKTOKEN is not None:
+    return _TIKTOKEN
+  try:
+    import tiktoken  # type: ignore
+
+    enc = tiktoken.get_encoding(encoder_name)
+    _TIKTOKEN = enc
+  except Exception:
+    _TIKTOKEN = None
+  return _TIKTOKEN
+
+
+def _lazy_import_bertscore():
+  global _BERT_SCORE
+  if _BERT_SCORE is not None:
+    return _BERT_SCORE
+  try:
+    from bert_score import score  # type: ignore
+
+    _BERT_SCORE = score
+  except Exception:
+    _BERT_SCORE = None
+  return _BERT_SCORE
+
+
+_ARTICLE_RE = re.compile(r"\b(a|an|the)\b", flags=re.IGNORECASE)
+_PUNCT_RE = re.compile(r"[^\w\s]")
+_WS_RE = re.compile(r"\s+")
+
+_FRACTION_RE = re.compile(
+  r"""
+(?P<whole>-?\d+)? # optional whole number (may be negative)
+(?:\s+)? # optional space
+(?P<num>\d+)\s*/\s*(?P<den>\d+) # numerator/denominator
+""",
+  re.VERBOSE,
+)
+
+_NUM_RE = re.compile(
+  r"""
+(?P<sign>[-+]?)
+(
+  (?P<intg>\d{1,3}(?:,\d{3})+|\d+)(?:\.(?P<frac>\d+))? # 1,234 or 1234 or 1,234.56
+  |
+  \.(?P<leadfrac>\d+) # .5
+)
+""",
+  re.VERBOSE,
+)
+
+_BOXED_RE = re.compile(r"\\boxed\s*\{([^}]*)\}")
+
+
+def _normalize(text: str) -> str:
+  s = (text or "").lower()
+  s = _PUNCT_RE.sub(" ", s)
+  s = _ARTICLE_RE.sub(" ", s)
+  s = _WS_RE.sub(" ", s).strip()
+  return s
+
+
+_YES_EQUIV = {"yes", "true", "y", "1", "correct"}
+_NO_EQUIV = {"no", "false", "n", "0", "incorrect"}
+
+
+def _yn_canonical(s: str) -> Optional[str]:
+  ss = _normalize(s)
+  if ss in _YES_EQUIV:
+    return "yes"
+  if ss in _NO_EQUIV:
+    return "no"
+  return None
+
+
+def _last_fraction_as_fraction(s: str) -> Optional[Fraction]:
+  matches = list(_FRACTION_RE.finditer(s))
+  if not matches:
+    return None
+  m = matches[-1]
+  num = int(m.group("num"))
+  den = int(m.group("den"))
+  whole_str = m.group("whole")
+  frac = Fraction(num, den)
+  if whole_str is not None:
+    whole = int(whole_str)
+    sign = -1 if whole < 0 else 1
+    frac = Fraction(abs(whole), 1) + frac
+    frac *= sign
+  return frac
+
+
+def _last_number_as_fraction(s: str) -> Optional[Fraction]:
+  frac = _last_fraction_as_fraction(s)
+  if frac is not None:
+    return frac
+  matches = list(_NUM_RE.finditer(s))
+  if not matches:
+    return None
+  m = matches[-1]
+  sign = -1 if m.group("sign") == "-" else 1
+  if m.group("leadfrac"):
+    dec_str = "0." + m.group("leadfrac")
+  else:
+    intg = m.group("intg").replace(",", "")
+    frac_part = m.group("frac")
+    dec_str = intg if frac_part is None else f"{intg}.{frac_part}"
+  try:
+    dec = Decimal(dec_str)
+    f = Fraction(dec)
+    return -f if sign == -1 else f
+  except (InvalidOperation, ValueError):
+    return None
+
+
+def _strip_latex_wrappers(s: str) -> str:
+  out = _BOXED_RE.sub(lambda m: m.group(1), s)
+  out = out.replace("\\(", "").replace("\\)", "").replace("\\[", "").replace("\\]", "")
+  return out
+
+
+@dataclass
+class MetricsComputer:
+  use_tiktoken: bool = False
+  encoder_name: str = "cl100k_base"
+
+  def __post_init__(self):
+    self._encoder = _lazy_import_tiktoken(self.encoder_name) if self.use_tiktoken else None
+
+  def count_tokens(self, text: str) -> int:
+    s = "" if text is None else str(text)
+    if self._encoder is not None:
+      try:
+        return len(self._encoder.encode(s))
+      except Exception:
+        pass
+    n = len(s)
+    return math.ceil(n / 4) if n else 0
+
+  def exact_match(self, pred: str, gold: str) -> bool:
+    p_can = _yn_canonical(pred)
+    g_can = _yn_canonical(gold)
+    if p_can is not None and g_can is not None:
+      return p_can == g_can
+    return _normalize(pred) == _normalize(gold)
+
+  def gsm8k_correct(self, pred: str, gold: str) -> bool:
+    pred_s = _strip_latex_wrappers(pred or "")
+    gold_s = _strip_latex_wrappers(gold or "")
+    p_val = _last_number_as_fraction(pred_s)
+    g_val = _last_number_as_fraction(gold_s)
+    if p_val is None or g_val is None:
+      return False
+    return p_val == g_val
+
+  def jaccard_sp(self, reference: str, candidate: str) -> float:
+    ref = set((_normalize(reference) or "").split())
+    cand = set((_normalize(candidate) or "").split())
+    if not ref and not cand:
+      return 1.0
+    if not ref or not cand:
+      return 0.0
+    return len(ref & cand) / len(ref | cand)
+
+  def bertscore_sp(self, reference: str, candidate: str, force_fallback: bool = False) -> float:
+    if force_fallback:
+      return self.jaccard_sp(reference, candidate)
+    scorer = _lazy_import_bertscore()
+    if scorer is None:
+      return self.jaccard_sp(reference, candidate)
+    try:
+      P, R, F1 = scorer([candidate], [reference], lang="en")
+      return float(F1[0].item())
+    except Exception:
+      return self.jaccard_sp(reference, candidate)
+
+  def measure_generation_timing(self, start: float, ttft: float, end: float, tokens: int) -> dict:
+    total = max(0.0, end - start)
+    ttft_ms = max(0.0, (ttft - start) * 1000.0)
+    if tokens and tokens > 1 and end > ttft:
+      itl_ms = ((end - ttft) / (tokens - 1)) * 1000.0
+    else:
+      itl_ms = 0.0
+    tps = (tokens / total) if (tokens > 0 and total > 0) else 0.0
+    return {"tps": tps, "ttft_ms": ttft_ms, "itl_ms": itl_ms, "total_time_s": total}
+
+  def bytes_on_wire(self, payload: Union[str, Iterable[str]]) -> int:
+    if isinstance(payload, str):
+      return len(payload.encode("utf-8"))
+    total = 0
+    for p in payload:
+      total += len(str(p).encode("utf-8"))
+    return total
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import math
+from tersetalk.metrics import MetricsComputer
+
+
+def test_em_normalization_and_yes_no():
+  mc = MetricsComputer()
+  assert mc.exact_match("The Eiffel; Tower", "eiffel tower")
+  assert mc.exact_match("YES", "true")
+  assert mc.exact_match("No", "FALSE")
+  assert not mc.exact_match("paris", "london")
+
+
+def test_gsm8k_integer_decimal_fraction_mixed_and_boxed():
+  mc = MetricsComputer()
+  assert mc.gsm8k_correct("Result: \\boxed{42}", "42")
+  assert mc.gsm8k_correct("Therefore 1,234.50", "1234.5")
+  assert mc.gsm8k_correct("the value is -12", "-12")
+  assert mc.gsm8k_correct("ratio = 3/4", "0.75")
+  assert mc.gsm8k_correct("time = 1 3/4 hours", "7/4")
+
+
+def test_jaccard_and_bertscore_fallback():
+  mc = MetricsComputer()
+  j = mc.jaccard_sp("a b c", "a c d")
+  # 'a' is an article and removed by normalization, so sets are {b,c} and {c,d} → 1/3
+  assert abs(j - (1.0/3.0)) < 1e-9
+  bf = mc.bertscore_sp("a b c", "a c d", force_fallback=True)
+  assert abs(bf - j) < 1e-9
+
+
+def test_token_count_heuristic_is_reasonable():
+  mc = MetricsComputer(use_tiktoken=False)
+  assert mc.count_tokens("") == 0
+  assert mc.count_tokens("abcd") == 1
+  assert mc.count_tokens("hello") == 2
+
+
+def test_timing_metrics_shapes_and_values():
+  mc = MetricsComputer()
+  res = mc.measure_generation_timing(start=0.0, ttft=0.02, end=0.12, tokens=6)
+  assert set(res.keys()) == {"tps", "ttft_ms", "itl_ms", "total_time_s"}
+  assert res["total_time_s"] > 0
+  assert res["ttft_ms"] > 0
+  assert res["tps"] > 0
+  assert res["itl_ms"] > 0
+
+
+def test_bytes_on_wire_str_and_list():
+  mc = MetricsComputer()
+  s = "€"
+  assert mc.bytes_on_wire(s) == len(s.encode("utf-8"))
+  lines = ["a", "€"]
+  assert mc.bytes_on_wire(lines) == sum(len(x.encode("utf-8")) for x in lines)

--- a/tests/test_pipeline_robustness.py
+++ b/tests/test_pipeline_robustness.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import List
+
+from tersetalk.pipeline_runner import PipelineConfig, run_pipeline_once
+from tersetalk.datasets import load_hotpotqa
+from tersetalk.structured import TerseTalkLine
+
+
+class FailingWorkerClient:
+  def call_jsonl_strict(self, system: str, user_prompt: str, max_tokens: int = 256):
+    raise RuntimeError("simulated worker failure")
+
+
+class FailingCriticClient:
+  def __init__(self):
+    self._first = True
+
+  def call_jsonl_strict(self, system: str, user_prompt: str, max_tokens: int = 256) -> List[TerseTalkLine]:
+    if self._first:
+      self._first = False
+      # Return a minimal worker line
+      return [TerseTalkLine(tag="g", payload=["ok worker"]) ]
+    raise RuntimeError("simulated critic failure")
+
+
+def test_pipeline_handles_worker_failure(monkeypatch):
+  monkeypatch.setenv("TERSETALK_OFFLINE_DATA", "1")
+  ex = load_hotpotqa(n=1, seed=1)[0]
+  cfg = PipelineConfig(caps={})
+  client = FailingWorkerClient()
+  res = run_pipeline_once(ex, client, cfg)
+  assert res["status"] == "error"
+  assert "worker_error" in res
+  # Density and overflow computed from manager_jsonl still exist
+  assert isinstance(res["density"], float)
+  assert "manager_jsonl" in res
+
+
+def test_pipeline_handles_critic_failure(monkeypatch):
+  monkeypatch.setenv("TERSETALK_OFFLINE_DATA", "1")
+  ex = load_hotpotqa(n=1, seed=2)[0]
+  cfg = PipelineConfig(caps={})
+  client = FailingCriticClient()
+  res = run_pipeline_once(ex, client, cfg)
+  assert res["status"] == "error"
+  assert "critic_error" in res
+  assert isinstance(res["density"], float)
+  assert "manager_jsonl" in res
+


### PR DESCRIPTION
PR‑09R/09T/10 — Pipeline robustness + optional tokenizer + metrics module

Summary
- PR‑09R: Robust pipeline real smokes
  - Wrap Worker/Critic structured calls in try/except.
  - Result dict includes `status` (ok|error) and `worker_error`/`critic_error` when applicable.
  - Still computes density/overflow and resets memory.
  - Tests: `tests/test_pipeline_robustness.py` simulates Worker and Critic failures without crashing.
- PR‑09T: Optional tokenizer (tiktoken)
  - MetricsComputer supports exact token counts when tiktoken is present; fallback to ceil(len/4) otherwise.
  - Tests cover heuristic path; presence path is import‑guarded.
- PR‑10: Metrics module
  - `tersetalk/metrics.py` with MetricsComputer providing:
    - `count_tokens`; `exact_match` (SQuAD/Hotpot normalization + yes/no); `gsm8k_correct` (rational last-number extraction; decimals/fractions/mixed; LaTeX boxed{}); `bertscore_sp` (fallback to Jaccard); `jaccard_sp`; `measure_generation_timing`; `bytes_on_wire`.
  - Smoke: `scripts/metrics_smoke.py` prints a JSON summary.
  - Tests: `tests/test_metrics.py` cover EM, GSM8K, SP fallback, token heuristic, timing, bytes-on-wire.
- Exports: add `metrics` to `tersetalk/__init__.py` and top-level `MetricsComputer` import.

Evidence (.venv)
1) Pytest: all green

2) Metrics smoke:
```
python -m scripts.metrics_smoke
→ JSON shows {em_demo, gsm8k_demo, sp_demo, token_count_demo, timing_demo, bytes_on_wire_demo}
```

3) Real runs (Ollama; repeated from prior PR comment for continuity):
- HotpotQA (free-form): tokens_total=269; answer: Richard Strauss
- GSM8K (free-form): tokens_total=172; answer: $100
- Pipeline (structured): previously failed due to tool semantics; this PR adds robust error capture so the smoke won’t crash and will record status and error text. I will re-run after merge.

Reviews
- Self-review: ✅ scope matches proposal; tests/smokes complete; CI-safe.
- Claude review: Pending — refs-only (reads @RESEARCH_PROPOSAL.md first) starting now.
- Final self-review: Will re-run after Claude feedback.

Notes & rationale
- Robust pipeline: enables real smokes even when model doesn’t adhere to Instructor tooling.
- Metrics: lightweight, optional deps guarded; exact where possible, honest fallbacks otherwise.

