### PR TITLE
PR-13: baselines parameters & robustness (+ smoke CLI)

### DIFF
--- a/scripts/baselines_smoke.py
+++ b/scripts/baselines_smoke.py
@@ -17,6 +17,7 @@ def main():
   ap.add_argument("--model", choices=["echo", "real"], default="echo")
   ap.add_argument("--disable-ll2", action="store_true", help="Force disable LLMLingua via env")
   ap.add_argument("--max-tokens", type=int, default=256, help="Max tokens for baseline generation")
+  ap.add_argument("--target-compression", type=int, default=200, help="Target compressed tokens for LLMLingua path")
   args = ap.parse_args()
 
   if args.disable_ll2:
@@ -43,7 +44,7 @@ def main():
   print(json.dumps(res_free, indent=2))
 
   print("\n=== Free-form + LLMLingua baseline ===")
-  res_ll2 = run_llmlingua_once(ex, client, target_token=200, max_tokens=args.max_tokens)
+  res_ll2 = run_llmlingua_once(ex, client, target_token=int(args.target_compression), max_tokens=args.max_tokens)
   print(json.dumps(res_ll2, indent=2))
 
 

--- a/tests/test_baselines_params.py
+++ b/tests/test_baselines_params.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from tersetalk.baselines import run_freeform_once
+from tersetalk.hybrid_gate import estimate_tokens
+
+
+class FailingClient:
+    def call_text(self, system: str, user_prompt: str, max_tokens: int = 256) -> str:  # type: ignore[override]
+        raise RuntimeError("boom")
+
+
+class EchoClient:
+    def call_text(self, system: str, user_prompt: str, max_tokens: int = 256) -> str:  # type: ignore[override]
+        return "OK"
+
+
+def test_freeform_success_echo():
+    ex = {"question": "test?", "facts": [], "assumptions": [], "subgoal": "Answer."}
+    res = run_freeform_once(ex, EchoClient(), max_tokens=123)
+    assert res["status"] == "success"
+    assert res["tokens"] >= estimate_tokens("")
+    assert isinstance(res["tokens_total"], int)
+
+
+def test_freeform_error_handling():
+    ex = {"question": "test?", "facts": [], "assumptions": [], "subgoal": "Answer."}
+    res = run_freeform_once(ex, FailingClient(), max_tokens=64)
+    assert res["status"] == "error"
+    assert res["tokens"] >= 0
+    assert res["tokens_total"] >= 0
+


### PR DESCRIPTION
PR-13 — Baselines Parameters & Robustness (+ smoke CLI)

Summary
- Parameterize baselines and add robust error handling without changing defaults or schema.
- Extend baselines smoke CLI with target compression knob; offline-safe by default.

Changes
- tersetalk/baselines.py:
  * run_freeform_once: wraps client call in try/except; adds status + tokens fields; preserves existing fields
  * run_llmlingua_once: adds status; keeps env-guarded fallback; uses estimate_tokens; non-crashing error path
- scripts/baselines_smoke.py:
  * Adds --target-compression; honors RUN_REAL_MODEL for real-model smoke
- tests/test_baselines_params.py:
  * Covers success and error paths with minimal clients; checks status and tokens

Evidence
- .venv used; pytest all green locally
- Echo offline smoke prints both baselines with status=success. Injected failing client returns status=error and non-negative tokens

Alignment & Scope
- Matches RESEARCH_PROPOSAL.md v0.5 baseline configurability and robustness goals
- Diff small and focused; no new heavy deps; backward compatible

Review Protocol
- Self-review: tests green; schema preserved; defaults identical
- Claude Code review (with @RESEARCH_PROPOSAL.md + @file refs): Approved: no nits.
- Final self-review: no further changes needed

Please review; holding merge until approval.
