### PR TITLE
PR-22: Prompt discipline (final answer only)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,3 +429,19 @@ You are writing code to test the minimal viable research proposal.
   - Summary: Adds `tersetalk/statistics.py` (numpy-only bootstrap: paired CI, percent reduction, mean CI, one-sided p, noninferiority) and `scripts/run_significance.py` CLI. Produces concise console lines and `significance_tests.json` from PR‑14 JSONL outputs.
   - Evidence: pytest green; `tests/test_statistics_smoke.py` creates minimal aligned rows and verifies JSON output; Claude review Approved: no nits.
   - Next: Run on Ollama evaluation outputs (phi, llama3.1:8b) to quantify token reductions and quality deltas; attach reports to PRs.
+
+
+- PR-19 — Worker Fallback (Ollama-safe):
+  - Summary: Adds Worker text fallback when Instructor fails; wraps final answer as TerseTalk ["f", ...]; status OK on success.
+  - Evidence: tests green; reduced error rows in pipeline on Ollama.
+  - Next: Add Critic fallback to avoid dropping rows when Critic schema fails.
+
+- PR-20 — Temperature + Instruct-run Plan (n=2):
+  - Summary: Adds temperature controls to ModelClient/baselines; updates PROMPT with instruct-run plan (n=2).
+  - Evidence: pytest green; codellama:13b-instruct freeform runs (n=2) completed; figures generated.
+  - Next: Execute joint runs with tersetalk+freeform; produce significance JSON.
+
+- PR-21 — Critic Fallback (text):
+  - Summary: Adds Critic text fallback (A/R/E) when structured validation fails; complements Worker fallback to preserve rows.
+  - Evidence: tests green; ready to re-run instruct evaluations and analysis.
+  - Next: Run paired instruct evaluations (n=2), analyze (Pareto), run significance, attach artifacts.

--- a/PROMPT.md
+++ b/PROMPT.md
@@ -2,7 +2,39 @@ Read through your @AGENTS.md and ensure you follow that precisely. Make sure you
 
 ### PR Summary
 
-PR‑20 — Instruct Model Runs (n=2) + Strict Generation Settings
+PR‑21 — Critic Fallback + Instruct Runs (n=2) & Analysis
+
+Scope (≤250 LOC where needed):
+- Add Critic fallback (text verdict A/R/E) when structured Critic fails (done)
+- Run paired, real‑data instruct evaluations (n=2) with low temperature and strict formatting
+- Generate figures (Pareto) and significance JSON; attach paths and short analysis
+
+Settings & Models
+- Temperature: 0.2; max_tokens: 256–384 where applicable
+- Systems: tersetalk (Worker+Critic fallback), freeform (final answer only), hybrid/llmlingua if time permits (guarded)
+- Tasks: hotpotqa and gsm8k; Seeds: [0]
+- Per‑role models: codellama:13b-instruct (Ollama); if llama3.1:8b-instruct-q8_0 is available locally, prefer it
+
+Commands (example)
+- export OLLAMA_MODEL="codellama:13b-instruct"
+- python scripts/run_evaluation.py --task hotpotqa \
+  --systems tersetalk --systems freeform --n 2 --seed 0 \
+  --model "$OLLAMA_MODEL" --worker-model "$OLLAMA_MODEL" --critic-model "$OLLAMA_MODEL" \
+  --temperature 0.2 --out results/eval_instruct_joint_htpq --no-caps-grid
+- Repeat for gsm8k to results/eval_instruct_joint_gsm8k
+
+Analysis
+- python scripts/analyze_v05.py --indir results/eval_instruct_joint_htpq --outdir results/eval_instruct_joint_htpq/figures
+- Artifacts: pareto_points.csv, pareto_frontier.pdf (ablation optional if caps grid on)
+
+Significance (paired)
+- python scripts/run_significance.py --results-dir results/eval_instruct_joint_htpq/hotpotqa/<timestamp> --boots 2000
+- Uses tersetalk_baseline.jsonl symlink and freeform.jsonl in same dir
+
+Acceptance
+- Both tasks produce non‑NaN paired stats and non‑error rows for tersetalk
+- Pareto artifacts saved; console summaries present; short analysis attached
+
 
 Scope (≤250 LOC where needed):
 - Use Ollama instruct model `llama3.1:8b-instruct-q8_0` where available

--- a/tersetalk/pipeline_runner.py
+++ b/tersetalk/pipeline_runner.py
@@ -205,7 +205,7 @@ def run_pipeline_once(
     # Fallback: request a concise final answer via text, then wrap as a simple TerseTalk line
     try:
       text = (client_worker or client).call_text(
-        system="You are a Worker. Read the JSONL and provide a concise final answer only.",
+        system="You are a Worker. Read the JSONL and return only the final answer with no extra words.",
         user_prompt=validated_jsonl,
         max_tokens=128,
       )
@@ -234,7 +234,7 @@ def run_pipeline_once(
       # Critic fallback: request a one-letter verdict; default to 'A' if undecidable
       try:
         txt = (client_critic or client).call_text(
-          system="You are a Critic. Read the JSONL and return only one letter: A (accept), R (revise), or E (error).",
+          system="You are a Critic. Read the JSONL and return only one letter: A (accept), R (revise), or E (error). No extra words.",
           user_prompt=critic_input,
           max_tokens=16,
         )


### PR DESCRIPTION
Enforce final-answer-only prompts; strip 'Final answer:' prefixes in baselines; tighten fallback prompts. Pytests green. Preps for improved EM with instruct models.